### PR TITLE
Add header & footer sections to reports

### DIFF
--- a/lider-core/src/main/java/tr/org/liderahenk/lider/core/api/rest/enums/PdfReportParamType.java
+++ b/lider-core/src/main/java/tr/org/liderahenk/lider/core/api/rest/enums/PdfReportParamType.java
@@ -1,0 +1,39 @@
+package tr.org.liderahenk.lider.core.api.rest.enums;
+
+public enum PdfReportParamType {
+
+	PAGE_NO(1), DATE(2), TEXT(3);
+
+	private int id;
+
+	private PdfReportParamType(int id) {
+		this.id = id;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	/**
+	 * Provide mapping enums with a fixed ID in JPA (a more robust alternative
+	 * to EnumType.String and EnumType.Ordinal)
+	 * 
+	 * @param id
+	 * @return related PdfReportParamType enum
+	 * @see http://blog.chris-ritchie.com/2013/09/mapping-enums-with-fixed-id-in
+	 *      -jpa.html
+	 * 
+	 */
+	public static PdfReportParamType getType(Integer id) {
+		if (id == null) {
+			return null;
+		}
+		for (PdfReportParamType type : PdfReportParamType.values()) {
+			if (id.equals(type.getId())) {
+				return type;
+			}
+		}
+		throw new IllegalArgumentException("No matching type for id: " + id);
+	}
+
+}

--- a/lider-core/src/main/java/tr/org/liderahenk/lider/core/api/rest/requests/IReportGenerationRequest.java
+++ b/lider-core/src/main/java/tr/org/liderahenk/lider/core/api/rest/requests/IReportGenerationRequest.java
@@ -2,6 +2,8 @@ package tr.org.liderahenk.lider.core.api.rest.requests;
 
 import java.util.Map;
 
+import tr.org.liderahenk.lider.core.api.rest.enums.PdfReportParamType;
+
 /**
  * Request class for report generation.
  * 
@@ -13,5 +15,21 @@ public interface IReportGenerationRequest extends IRequest {
 	Long getViewId();
 
 	Map<String, Object> getParamValues();
+
+	PdfReportParamType getTopLeft();
+
+	String getTopLeftText();
+
+	PdfReportParamType getTopRight();
+
+	String getTopRightText();
+
+	PdfReportParamType getBottomLeft();
+
+	String getBottomLeftText();
+
+	PdfReportParamType getBottomRight();
+
+	String getBottomRightText();
 
 }

--- a/lider-service-impl/src/main/java/tr/org/liderahenk/lider/service/requests/ReportGenerationRequestImpl.java
+++ b/lider-service-impl/src/main/java/tr/org/liderahenk/lider/service/requests/ReportGenerationRequestImpl.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
+import tr.org.liderahenk.lider.core.api.rest.enums.PdfReportParamType;
 import tr.org.liderahenk.lider.core.api.rest.requests.IReportGenerationRequest;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -15,6 +16,22 @@ public class ReportGenerationRequestImpl implements IReportGenerationRequest {
 	private Long viewId;
 
 	private Map<String, Object> paramValues;
+
+	private PdfReportParamType topLeft;
+
+	private String topLeftText;
+
+	private PdfReportParamType topRight;
+
+	private String topRightText;
+
+	private PdfReportParamType bottomLeft;
+
+	private String bottomLeftText;
+
+	private PdfReportParamType bottomRight;
+
+	private String bottomRightText;
 
 	private Date timestamp;
 
@@ -34,6 +51,78 @@ public class ReportGenerationRequestImpl implements IReportGenerationRequest {
 
 	public void setParamValues(Map<String, Object> paramValues) {
 		this.paramValues = paramValues;
+	}
+
+	@Override
+	public PdfReportParamType getTopLeft() {
+		return topLeft;
+	}
+
+	public void setTopLeft(PdfReportParamType topLeft) {
+		this.topLeft = topLeft;
+	}
+
+	@Override
+	public String getTopLeftText() {
+		return topLeftText;
+	}
+
+	public void setTopLeftText(String topLeftText) {
+		this.topLeftText = topLeftText;
+	}
+
+	@Override
+	public PdfReportParamType getTopRight() {
+		return topRight;
+	}
+
+	public void setTopRight(PdfReportParamType topRight) {
+		this.topRight = topRight;
+	}
+
+	@Override
+	public String getTopRightText() {
+		return topRightText;
+	}
+
+	public void setTopRightText(String topRightText) {
+		this.topRightText = topRightText;
+	}
+
+	@Override
+	public PdfReportParamType getBottomLeft() {
+		return bottomLeft;
+	}
+
+	public void setBottomLeft(PdfReportParamType bottomLeft) {
+		this.bottomLeft = bottomLeft;
+	}
+
+	@Override
+	public String getBottomLeftText() {
+		return bottomLeftText;
+	}
+
+	public void setBottomLeftText(String bottomLeftText) {
+		this.bottomLeftText = bottomLeftText;
+	}
+
+	@Override
+	public PdfReportParamType getBottomRight() {
+		return bottomRight;
+	}
+
+	public void setBottomRight(PdfReportParamType bottomRight) {
+		this.bottomRight = bottomRight;
+	}
+
+	@Override
+	public String getBottomRightText() {
+		return bottomRightText;
+	}
+
+	public void setBottomRightText(String bottomRightText) {
+		this.bottomRightText = bottomRightText;
 	}
 
 	@Override


### PR DESCRIPTION
Users can add header&footer (containing report date, page no or custom text) in generated reports.
Related Lider Console changes will also be committed.