### PR TITLE
Bug fix for agent property update during re-registration

### DIFF
--- a/lider-persistence-mariadb/src/main/java/tr/org/liderahenk/lider/persistence/entities/AgentImpl.java
+++ b/lider-persistence-mariadb/src/main/java/tr/org/liderahenk/lider/persistence/entities/AgentImpl.java
@@ -237,7 +237,17 @@ public class AgentImpl implements IAgent {
 		if (propertyImpl.getAgent() != this) {
 			propertyImpl.setAgent(this);
 		}
-		properties.add(propertyImpl);
+		boolean found = false;
+		for (AgentPropertyImpl tmp : properties) {
+			if (tmp.equals(propertyImpl)) {
+				tmp.setPropertyValue(propertyImpl.getPropertyValue());
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			properties.add(propertyImpl);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Agent properties (ipAddress, os.name etc.) couldn't be updated if there is already one agent property with the same name.

How to test/reproduce:
1. Check and note down a changeable Ahenk property (e.g. _ipAddress_ = 192.168.1.88)
2. Clean and restart Ahenk by issuing command: `sudo service ahenk stop && sudo /opt/ahenk/ahenkd.py clean && sudo service ahenk start` Ahenk should be registered again, and its properties should be updated...
3. Check the same property again (IP address should be updated. e.g. _ipAddress_ = 192.168.1.102)
