### PR TITLE
Avoid redundant override

### DIFF
--- a/lider-web/src/main/java/tr/org/liderahenk/web/security/LiderLdapRealm.java
+++ b/lider-web/src/main/java/tr/org/liderahenk/web/security/LiderLdapRealm.java
@@ -72,11 +72,6 @@ public class LiderLdapRealm extends AbstractLdapRealm {
 	}
 
 	@Override
-	public void setSystemPassword(String systemPassword) {
-		super.setSystemPassword(systemPassword);
-	}
-
-	@Override
 	protected AuthenticationInfo queryForAuthenticationInfo(AuthenticationToken token,
 			LdapContextFactory contextFactory) throws NamingException {
 


### PR DESCRIPTION
The overriding method merely calls the same method
defined in a superclass. There is a RunTime penalty.